### PR TITLE
Extend JKind's API to Support Kind 2's Contracts

### DIFF
--- a/com.collins.trustedsystems.jkindapi/src/jkind/api/examples/coverage/ExtractorVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/api/examples/coverage/ExtractorVisitor.java
@@ -54,7 +54,8 @@ public class ExtractorVisitor extends TypeAwareAstMapVisitor {
 		boolean enumsAsInts = false;
 		typeReconstructor = new TypeReconstructor(e, enumsAsInts);
 		constants = e.constants.stream().map(c -> c.id).collect(toSet());
-		return new Program(e.location, e.types, e.constants, visitFunctions(e.functions), visitNodes(e.nodes), e.main);
+		return new Program(e.location, e.types, e.constants, visitFunctions(e.functions), e.importedFunctions,
+				e.importedNodes, e.contracts, e.kind2Functions, visitNodes(e.nodes), e.main);
 	}
 
 	@Override

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Assume.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Assume.java
@@ -1,0 +1,40 @@
+package jkind.lustre;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+
+/**
+ * This class represents a contract assumption. An assumption over a node
+ * {@code n} is a constraint one must respect in order to use {@code n} legally.
+ * It cannot mention the outputs of {@code n} in the current state, but
+ * referring to outputs under a {@code pre} is fine.
+ */
+public class Assume extends ContractItem {
+	public final Expr expr;
+
+	/**
+	 * Constructor
+	 *
+	 * @param location location of assumption in a Lustre file
+	 * @param expr     an expression representing a constraint
+	 */
+	public Assume(Location location, Expr expr) {
+		super(location);
+		Assert.isNotNull(expr);
+		this.expr = expr;
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param expr an expression representing a constraint
+	 */
+	public Assume(Expr expr) {
+		this(Location.NULL, expr);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Constant.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Constant.java
@@ -3,7 +3,7 @@ package jkind.lustre;
 import jkind.Assert;
 import jkind.lustre.visitors.AstVisitor;
 
-public class Constant extends Ast {
+public class Constant extends ContractItem {
 	public final String id;
 	public final Type type;
 	public final Expr expr;

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Contract.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Contract.java
@@ -2,21 +2,55 @@ package jkind.lustre;
 
 import java.util.List;
 
+import jkind.Assert;
 import jkind.lustre.visitors.AstVisitor;
 import jkind.util.Util;
 
+/**
+ * This class represents a contract node. A contract node is very similar to a
+ * traditional Lustre node. The two differences are that
+ * <ul>
+ * <li>it starts with {@code contract} instead of {@code node} and</li>
+ * <li>its body can only mention contract items.</li>
+ * </ul>
+ * To use a contract node one needs to import it through an inline contract.
+ */
 public class Contract extends Ast {
-	public final List<Expr> requires;
-	public final List<Expr> ensures;
+	public final String id;
+	public final List<VarDecl> inputs;
+	public final List<VarDecl> outputs;
+	public final ContractBody contractBody;
 
-	public Contract(Location location, List<Expr> requires, List<Expr> ensures) {
+	/**
+	 * Constructor
+	 *
+	 * @param location     location of contract in a Lustre file
+	 * @param id           name of contract
+	 * @param inputs       inputs to this contract
+	 * @param outputs      outputs of this contract
+	 * @param contractBody body of this contract
+	 */
+	public Contract(Location location, String id, List<VarDecl> inputs, List<VarDecl> outputs,
+			ContractBody contractBody) {
 		super(location);
-		this.requires = Util.safeList(requires);
-		this.ensures = Util.safeList(ensures);
+		Assert.isNotNull(id);
+		this.id = id;
+		this.inputs = Util.safeList(inputs);
+		this.outputs = Util.safeList(outputs);
+		Assert.isNotNull(contractBody);
+		this.contractBody = contractBody;
 	}
 
-	public Contract(List<Expr> requires, List<Expr> ensures) {
-		this(Location.NULL, requires, ensures);
+	/**
+	 * Constructor
+	 *
+	 * @param id           name of this contract
+	 * @param inputs       inputs to this contract
+	 * @param outputs      outputs of this contract
+	 * @param contractBody body of this contract
+	 */
+	public Contract(String id, List<VarDecl> inputs, List<VarDecl> outputs, ContractBody contractBody) {
+		this(Location.NULL, id, inputs, outputs, contractBody);
 	}
 
 	@Override

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ContractBody.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ContractBody.java
@@ -1,0 +1,53 @@
+package jkind.lustre;
+
+import java.util.List;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+import jkind.util.Util;
+
+/**
+ * This class represents a contract body which can be embedded in a node's
+ * inline contract or an external contract node. The body is composed of items,
+ * each of which define
+ * <ul>
+ * <li>a ghost variable / constant,</li>
+ * <li>an assumption,</li>
+ * <li>a guarantee,</li>
+ * <li>a mode, or</li>
+ * <li>an import of a contract node.</li>
+ * </ul>
+ */
+public class ContractBody extends Ast {
+	/**
+	 * A list of contract items. Order matters, so we must use one list for all
+	 * items.
+	 */
+	public final List<ContractItem> items;
+
+	/**
+	 * Constructor
+	 *
+	 * @param location location of contract body in a Lustre file
+	 * @param items    a list of contract items
+	 */
+	public ContractBody(Location location, List<ContractItem> items) {
+		super(location);
+		Assert.isFalse(items.isEmpty()); // contract body must contain at least one item
+		this.items = Util.safeList(items);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param items a list of contract items
+	 */
+	public ContractBody(List<ContractItem> items) {
+		this(Location.NULL, items);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ContractImport.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ContractImport.java
@@ -1,0 +1,59 @@
+package jkind.lustre;
+
+import java.util.List;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+import jkind.util.Util;
+
+/**
+ * This class represents a contract import. A contract import merges the current
+ * contract with the one imported. That is, if the current contract is
+ * {@code (A,G,M)} and we import {@code (A',G',M')}, the resulting contract is
+ * {@code (A U A', G U G', M U M')} where U is set union.
+ * <p>
+ * When importing a contract, it is necessary to specify how the instantiation
+ * of the contract is performed. This defines a mapping from the input (output)
+ * formal parameters to the actual ones of the import.
+ * <p>
+ * When importing contract {@code c} in the contract of node {@code n}, it is
+ * <b>illegal</b> to mention an output of {@code n} in the actual input
+ * parameters of the import of {@code c}.
+ */
+public class ContractImport extends ContractItem {
+	public final String id;
+	public final List<Expr> inputs;
+	public final List<IdExpr> outputs;
+
+	/**
+	 * Constructor
+	 *
+	 * @param location location of contract import in a Lustre file
+	 * @param id       name of contract to import
+	 * @param inputs   inputs to the contract
+	 * @param outputs  outputs of the contract
+	 */
+	public ContractImport(Location loc, String id, List<Expr> inputs, List<IdExpr> outputs) {
+		super(loc);
+		Assert.isNotNull(id);
+		this.id = id;
+		this.inputs = Util.safeList(inputs);
+		this.outputs = Util.safeList(outputs);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id      name of contract to import
+	 * @param inputs  inputs of the contract
+	 * @param outputs outputs of the contract
+	 */
+	public ContractImport(String id, List<Expr> inputs, List<IdExpr> outputs) {
+		this(Location.NULL, id, inputs, outputs);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ContractItem.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ContractItem.java
@@ -1,0 +1,16 @@
+package jkind.lustre;
+
+/**
+ * This abstract class represents the items (i.e., statements) that can appear
+ * in a contract body.
+ */
+public abstract class ContractItem extends Ast {
+	/**
+	 * Constructor
+	 *
+	 * @param location location of contract item in a Lustre file
+	 */
+	public ContractItem(Location location) {
+		super(location);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Guarantee.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Guarantee.java
@@ -1,0 +1,40 @@
+package jkind.lustre;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+
+/**
+ * This class represents a contract guarantee. Unlike assumptions, guarantees do
+ * not have any restrictions on the streams they can mention. They typically
+ * mention the outputs in the current state since they express the behavior of
+ * the node they specified under the assumptions of this node.
+ */
+public class Guarantee extends ContractItem {
+	public final Expr expr;
+
+	/**
+	 * Constructor
+	 *
+	 * @param location location of guarantee in a Lustre file
+	 * @param expr     constraint expressing the behavior of a node
+	 */
+	public Guarantee(Location location, Expr expr) {
+		super(location);
+		Assert.isNotNull(expr);
+		this.expr = expr;
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param expr constraint expressing the behavior of a node
+	 */
+	public Guarantee(Expr expr) {
+		this(Location.NULL, expr);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ImportedFunction.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ImportedFunction.java
@@ -1,0 +1,64 @@
+package jkind.lustre;
+
+import java.util.List;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+import jkind.util.Util;
+
+/**
+ * This class represents an {@code imported} function. An imported function does
+ * not have a body {@code (let ... tel)}. In a Lustre compiler, this is usually
+ * used to encode a C function or more generally a call to an external library.
+ * <p>
+ * In Kind 2, this means that the function is always abstract in the contract
+ * sense. It can never be refined, and is always abstracted by its contract. If
+ * none is given, then the implicit (rather weak) contract
+ * {@code (*@contract assume true; guarantee true; *)} is used.
+ * <p>
+ * In a modular analysis, imported functions will not be analyzed, although if
+ * their contract has modes they will be checked for exhaustiveness,
+ * consistently with the usual Kind 2 contract workflow.
+ */
+public class ImportedFunction extends Ast {
+	public final String id;
+	public final List<VarDecl> inputs;
+	public final List<VarDecl> outputs;
+	public final ContractBody contractBody; // Nullable
+
+	/**
+	 * Constructor
+	 *
+	 * @param location     location of imported function in a Lustre file
+	 * @param id           name of this function
+	 * @param inputs       inputs to this function
+	 * @param outputs      outputs of this function
+	 * @param contractBody an inline contract
+	 */
+	public ImportedFunction(Location location, String id, List<VarDecl> inputs, List<VarDecl> outputs,
+			ContractBody contractBody) {
+		super(location);
+		Assert.isNotNull(id);
+		this.id = id;
+		this.inputs = Util.safeList(inputs);
+		this.outputs = Util.safeList(outputs);
+		this.contractBody = contractBody;
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id           name of this function
+	 * @param inputs       inputs to this function
+	 * @param outputs      outputs of this function
+	 * @param contractBody an inline contract
+	 */
+	public ImportedFunction(String id, List<VarDecl> inputs, List<VarDecl> outputs, ContractBody contractBody) {
+		this(Location.NULL, id, inputs, outputs, contractBody);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ImportedNode.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ImportedNode.java
@@ -1,0 +1,64 @@
+package jkind.lustre;
+
+import java.util.List;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+import jkind.util.Util;
+
+/**
+ * This class represents an {@code imported} node. An imported node does not
+ * have a body {@code (let ... tel)}. In a Lustre compiler, this is usually used
+ * to encode a C function or more generally a call to an external library.
+ * <p>
+ * In Kind 2, this means that the node is always abstract in the contract sense.
+ * It can never be refined, and is always abstracted by its contract. If none is
+ * given, then the implicit (rather weak) contract
+ * {@code (*@contract assume true; guarantee true; *)} is used.
+ * <p>
+ * In a modular analysis, imported nodes will not be analyzed, although if their
+ * contract has modes they will be checked for exhaustiveness, consistently with
+ * the usual Kind 2 contract workflow.
+ */
+public class ImportedNode extends Ast {
+	public final String id;
+	public final List<VarDecl> inputs;
+	public final List<VarDecl> outputs;
+	public final ContractBody contractBody; // Nullable
+
+	/**
+	 * Constructor
+	 *
+	 * @param location     location of imported node in a Lustre file
+	 * @param id           name of this node
+	 * @param inputs       inputs to this node
+	 * @param outputs      outputs of this node
+	 * @param contractBody an inline contract
+	 */
+	public ImportedNode(Location location, String id, List<VarDecl> inputs, List<VarDecl> outputs,
+			ContractBody contractBody) {
+		super(location);
+		Assert.isNotNull(id);
+		this.id = id;
+		this.inputs = Util.safeList(inputs);
+		this.outputs = Util.safeList(outputs);
+		this.contractBody = contractBody;
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id           name of node
+	 * @param inputs       inputs to this node
+	 * @param outputs      outputs of this node
+	 * @param contractBody an inline contract
+	 */
+	public ImportedNode(String id, List<VarDecl> inputs, List<VarDecl> outputs, ContractBody contractBody) {
+		this(Location.NULL, id, inputs, outputs, contractBody);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Kind2Function.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Kind2Function.java
@@ -1,0 +1,84 @@
+package jkind.lustre;
+
+import java.util.List;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+import jkind.util.Util;
+
+/**
+ * This class represents a Kind 2 function. Kind 2 supports the {@code function}
+ * keyword which is used just like the {@code node} one but has slightly
+ * different semantics. Like the name suggests, the output(s) of a function
+ * should be a <i>non-temporal</i> combination of its inputs. That is, a
+ * function cannot use the {@code ->}, {@code pre}, {@code merge}, {@code when},
+ * {@code condact}, or {@code activate} operators. A function is also not
+ * allowed to call a node, only other functions. In Lustre terms, functions are
+ * stateless.
+ * <p>
+ * In Kind 2, these restrictions extend to the contract attached to the
+ * function, if any. Note that besides the ones mentioned here, no additional
+ * restrictions are enforced on functions compared to nodes.
+ */
+public class Kind2Function extends Ast {
+	public final String id;
+	public final List<VarDecl> inputs;
+	public final List<VarDecl> outputs;
+	public final ContractBody contractBody; // Nullable
+	public final List<VarDecl> locals;
+	public final List<Equation> equations;
+	public final List<String> properties;
+	public final List<Expr> assertions;
+
+	/**
+	 * Constructor
+	 *
+	 * @param location     location of imported function in a Lustre file
+	 * @param id           name of this function
+	 * @param inputs       inputs to this function
+	 * @param outputs      outputs of this function
+	 * @param contractBody an inline contract
+	 * @param locals       local variables of this function
+	 * @param equations    equations relating inputs and locals to other locals and
+	 *                     outputs
+	 * @param assertions   assumptions made on this function
+	 * @param properties   properties to check on this function
+	 */
+	public Kind2Function(Location location, String id, List<VarDecl> inputs, List<VarDecl> outputs,
+			ContractBody contractBody, List<VarDecl> locals, List<Equation> equations, List<Expr> assertions,
+			List<String> properties) {
+		super(location);
+		Assert.isNotNull(id);
+		this.id = id;
+		this.inputs = Util.safeList(inputs);
+		this.outputs = Util.safeList(outputs);
+		this.contractBody = contractBody;
+		this.locals = Util.safeList(locals);
+		this.equations = Util.safeList(equations);
+		this.assertions = Util.safeList(assertions);
+		this.properties = Util.safeList(properties);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id           name of this function
+	 * @param inputs       inputs to this function
+	 * @param outputs      outputs of this function
+	 * @param contractBody an inline contract
+	 * @param locals       local variables of this function
+	 * @param equations    equations relating inputs and locals to other locals and
+	 *                     outputs
+	 * @param assertions   assumptions made on this function
+	 * @param properties   properties to check on this function
+	 */
+	public Kind2Function(String id, List<VarDecl> inputs, ContractBody contractBody, List<VarDecl> outputs,
+			List<VarDecl> locals, List<Equation> equations, List<Expr> assertions, List<String> properties) {
+		this(Location.NULL, id, inputs, outputs, contractBody, locals, equations, assertions, properties);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/LustreUtil.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/LustreUtil.java
@@ -135,6 +135,10 @@ public class LustreUtil {
 		return new IntExpr(i);
 	}
 
+	public static ModeRefExpr modeRef(String... path) {
+		return new ModeRefExpr(path);
+	}
+
 	public static Expr TRUE = new BoolExpr(true);
 	public static Expr FALSE = new BoolExpr(false);
 

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Mode.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Mode.java
@@ -1,0 +1,51 @@
+package jkind.lustre;
+
+import java.util.List;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+import jkind.util.Util;
+
+/**
+ * A mode {@code (R,E)} is a set of requires {@code R} and a set of ensures
+ * {@code E}. Requires have the same restrictions as assumptions: they cannot
+ * mention outputs of the node they specify in the current state. Ensures, like
+ * guarantees, have no restriction.
+ */
+public class Mode extends ContractItem {
+	public final String id;
+	public final List<Expr> require;
+	public final List<Expr> ensure;
+
+	/**
+	 * Constructor
+	 *
+	 * @param location location of mode in a Lustre file
+	 * @param id       name of this mode
+	 * @param require  a list of requirements for this mode
+	 * @param ensure   a list of constraints that express behavior in this mode
+	 */
+	public Mode(Location location, String id, List<Expr> require, List<Expr> ensure) {
+		super(location);
+		Assert.isNotNull(id);
+		this.id = id;
+		this.require = Util.safeList(require);
+		this.ensure = Util.safeList(ensure);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id      name of mode
+	 * @param require a list of requirements for this mode
+	 * @param ensure  a list of constraints that express behavior in this mode
+	 */
+	public Mode(String id, List<Expr> require, List<Expr> ensure) {
+		this(Location.NULL, id, require, ensure);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ModeRefExpr.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/ModeRefExpr.java
@@ -1,0 +1,47 @@
+package jkind.lustre;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jkind.Assert;
+import jkind.lustre.visitors.ExprVisitor;
+
+/**
+ * This class represents a mode reference. A mode reference is a Lustre
+ * expression of type {@code bool} just like any other Boolean expression. It
+ * can appear under a {@code pre}, be used in a node call or a contract import,
+ * etc. It is only legal <b>after</b> the mode item itself. That is, no
+ * forward/self-references are allowed.
+ */
+public class ModeRefExpr extends Expr {
+	public final List<String> path;
+
+	/**
+	 * Constructor
+	 *
+	 * @param location location of mode reference expression in a Lustre file
+	 * @param path     path to the mode
+	 */
+	public ModeRefExpr(Location location, String... path) {
+		super(location);
+		Assert.isFalse(path.length == 0);
+		for (String id : path) {
+			Assert.isNotNull(id);
+		}
+		this.path = Arrays.asList(path);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param path path to the mode
+	 */
+	public ModeRefExpr(String... path) {
+		this(Location.NULL, path);
+	}
+
+	@Override
+	public <T> T accept(ExprVisitor<T> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Node.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Node.java
@@ -16,11 +16,11 @@ public class Node extends Ast {
 	public final List<Expr> assertions;
 	public final List<String> ivc;
 	public final List<String> realizabilityInputs; // Nullable
-	public final Contract contract; // Nullable
+	public final ContractBody contractBody; // Nullable
 
 	public Node(Location location, String id, List<VarDecl> inputs, List<VarDecl> outputs, List<VarDecl> locals,
 			List<Equation> equations, List<String> properties, List<Expr> assertions, List<String> realizabilityInputs,
-			Contract contract, List<String> ivc) {
+			ContractBody contractBody, List<String> ivc) {
 		super(location);
 		Assert.isNotNull(id);
 		this.id = id;
@@ -32,14 +32,14 @@ public class Node extends Ast {
 		this.assertions = Util.safeList(assertions);
 		this.ivc = Util.safeList(ivc);
 		this.realizabilityInputs = Util.safeNullableList(realizabilityInputs);
-		this.contract = contract;
+		this.contractBody = contractBody;
 	}
 
 	public Node(String id, List<VarDecl> inputs, List<VarDecl> outputs, List<VarDecl> locals, List<Equation> equations,
-			List<String> properties, List<Expr> assertions, List<String> realizabilityInputs, Contract contract,
+			List<String> properties, List<Expr> assertions, List<String> realizabilityInputs, ContractBody contractBody,
 			List<String> ivc) {
 		this(Location.NULL, id, inputs, outputs, locals, equations, properties, assertions, realizabilityInputs,
-				contract, ivc);
+				contractBody, ivc);
 	}
 
 	@Override

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Program.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/Program.java
@@ -10,15 +10,25 @@ public class Program extends Ast {
 	public final List<TypeDef> types;
 	public final List<Constant> constants;
 	public final List<Function> functions;
+	public final List<ImportedFunction> importedFunctions;
+	public final List<ImportedNode> importedNodes;
+	public final List<Contract> contracts;
+	public final List<Kind2Function> kind2Functions;
 	public final List<Node> nodes;
 	public final String main;
 
-	public Program(Location location, List<TypeDef> types, List<Constant> constants, List<Function> functions,
-			List<Node> nodes, String main) {
+	public Program(Location location, List<TypeDef> types, List<Constant> constants,
+			List<Function> functions, List<ImportedFunction> importedFunctions,
+			List<ImportedNode> importedNodes, List<Contract> contracts, 
+			List<Kind2Function> kind2Functions, List<Node> nodes, String main) {
 		super(location);
 		this.types = Util.safeList(types);
 		this.constants = Util.safeList(constants);
 		this.functions = Util.safeList(functions);
+		this.importedFunctions = Util.safeList(importedFunctions);
+		this.importedNodes = Util.safeList(importedNodes);
+		this.contracts = Util.safeList(contracts);
+		this.kind2Functions = Util.safeList(kind2Functions);
 		this.nodes = Util.safeList(nodes);
 		if (main == null && nodes != null && nodes.size() > 0) {
 			this.main = nodes.get(nodes.size() - 1).id;
@@ -28,7 +38,7 @@ public class Program extends Ast {
 	}
 
 	public Program(Node... nodes) {
-		this(Location.NULL, null, null, null, Arrays.asList(nodes), null);
+		this(Location.NULL, null, null, null, null, null, null, null, Arrays.asList(nodes), null);
 	}
 
 	public Node getMainNode() {

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/VarDef.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/VarDef.java
@@ -1,0 +1,59 @@
+package jkind.lustre;
+
+import jkind.Assert;
+import jkind.lustre.visitors.AstVisitor;
+
+/**
+ * This class represents a ghost variable definition. A ghost variable is a
+ * stream that is local to the contract. That is, it is not accessible from the
+ * body of the node specified. Ghost variables are defined with the {@code var}
+ * keyword.
+ */
+public class VarDef extends ContractItem {
+	public final VarDecl varDecl;
+	public final Expr expr;
+
+	/**
+	 * Constructor
+	 *
+	 * @param location location of ghost variable definition in a Lustre file
+	 * @param varDecl  ghost variable's declaration
+	 * @param expr     expression specifying stream of values assigned to ghost
+	 *                 variable
+	 */
+	public VarDef(Location location, VarDecl varDecl, Expr expr) {
+		super(location);
+		this.varDecl = varDecl;
+		Assert.isNotNull(expr);
+		this.expr = expr;
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param location location of ghost variable definition in a Lustre file
+	 * @param id       name of ghost variable
+	 * @param type     type of ghost variable
+	 * @param expr     expression specifying stream of values assigned to ghost
+	 *                 variable
+	 */
+	public VarDef(Location location, String id, Type type, Expr expr) {
+		this(location, new VarDecl(id, type), expr);
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param id   name of ghost variable
+	 * @param type type of ghost variable
+	 * @param expr expression specifying stream of values assigned to ghost variable
+	 */
+	public VarDef(String id, Type type, Expr expr) {
+		this(Location.NULL, id, type, expr);
+	}
+
+	@Override
+	public <T, S extends T> T accept(AstVisitor<T, S> visitor) {
+		return visitor.visit(this);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/builders/ContractBodyBuilder.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/builders/ContractBodyBuilder.java
@@ -1,0 +1,256 @@
+package jkind.lustre.builders;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import jkind.lustre.Assume;
+import jkind.lustre.Constant;
+import jkind.lustre.ContractBody;
+import jkind.lustre.ContractImport;
+import jkind.lustre.ContractItem;
+import jkind.lustre.Expr;
+import jkind.lustre.Guarantee;
+import jkind.lustre.IdExpr;
+import jkind.lustre.Location;
+import jkind.lustre.Mode;
+import jkind.lustre.Type;
+import jkind.lustre.VarDef;
+
+/**
+ * This class provides helper functions for constructing a contract body.
+ */
+public class ContractBodyBuilder {
+	private final List<ContractItem> items;
+
+	/**
+	 * Constructor
+	 */
+	public ContractBodyBuilder() {
+		this.items = new ArrayList<>();
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param contractBody contract body to clone
+	 */
+	public ContractBodyBuilder(ContractBody contractBody) {
+		this.items = new ArrayList<>(contractBody.items);
+	}
+
+	/**
+	 * add a ghost constant
+	 *
+	 * @param constant the ghost constant to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addConstant(Constant constant) {
+		this.items.add(constant);
+		return this;
+	}
+
+	/**
+	 * add ghost constants
+	 *
+	 * @param constants a collection of ghost constants to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addConstants(Collection<Constant> constants) {
+		this.items.addAll(constants);
+		return this;
+	}
+
+	/**
+	 * create a ghost constant
+	 *
+	 * @param name name of ghost constant
+	 * @param type type of ghost constant
+	 * @param expr expression specifying value assigned to ghost constant
+	 * @return an expression referring to created ghost constant
+	 */
+	public IdExpr createConstant(String name, Type type, Expr expr) {
+		this.items.add(new Constant(name, type, expr));
+		return new IdExpr(name);
+	}
+
+	/**
+	 * add a ghost variable definition
+	 *
+	 * @param varDef the ghost variable definition to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addVarDef(VarDef varDef) {
+		this.items.add(varDef);
+		return this;
+	}
+
+	/**
+	 * add ghost variable definitions
+	 *
+	 * @param varDefs a collection of ghost variable definitions to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addVarDefs(Collection<VarDef> varDefs) {
+		this.items.addAll(varDefs);
+		return this;
+	}
+
+	/**
+	 * create a ghost variable
+	 *
+	 * @param name name of ghost variable
+	 * @param type type of ghost variable
+	 * @param expr expression specifying stream of values assigned to ghost variable
+	 * @return an expression referring to created ghost variable
+	 */
+	public IdExpr createVarDef(String name, Type type, Expr expr) {
+		this.items.add(new VarDef(name, type, expr));
+		return new IdExpr(name);
+	}
+
+	/**
+	 * add an assumption
+	 *
+	 * @param expr an expression representing a constraint
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addAssumption(Expr expr) {
+		this.items.add(new Assume(expr));
+		return this;
+	}
+
+	/**
+	 * add an assumption
+	 *
+	 * @param assumption assumption to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addAssumption(Assume assumption) {
+		this.items.add(assumption);
+		return this;
+	}
+
+	/**
+	 * add assumptions
+	 *
+	 * @param assumptions a collection of assumptions to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addAssumptions(Collection<Assume> assumptions) {
+		this.items.addAll(assumptions);
+		return this;
+	}
+
+	/**
+	 * add a guarantee
+	 *
+	 * @param expr constraint expressing the behavior of a node
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addGuarantee(Expr expr) {
+		this.items.add(new Guarantee(expr));
+		return this;
+	}
+
+	/**
+	 * add a guarantee
+	 *
+	 * @param guarantee guarantee to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addGuarantee(Guarantee guarantee) {
+		this.items.add(guarantee);
+		return this;
+	}
+
+	/**
+	 * add guarantees
+	 *
+	 * @param guarantees a collection of guarantees to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addGuarantees(Collection<Guarantee> guarantees) {
+		this.items.addAll(guarantees);
+		return this;
+	}
+
+	/**
+	 * add a mode
+	 *
+	 * @param id      name of this mode
+	 * @param require a list of requirements for this mode
+	 * @param ensure  a list of constraints that express behavior in this mode
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addMode(String id, List<Expr> require, List<Expr> ensure) {
+		this.items.add(new Mode(id, require, ensure));
+		return this;
+	}
+
+	/**
+	 * add a mode
+	 *
+	 * @param mode mode to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addMode(Mode mode) {
+		this.items.add(mode);
+		return this;
+	}
+
+	/**
+	 * add modes
+	 *
+	 * @param modes a collection of modes to add
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addModes(Collection<Mode> modes) {
+		this.items.addAll(modes);
+		return this;
+	}
+
+	/**
+	 * import a contract
+	 *
+	 * @param id      name of contract to import
+	 * @param inputs  inputs to the contract
+	 * @param outputs outputs of the contract
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder importContract(String name, List<Expr> inputs, List<IdExpr> outputs) {
+		this.items.add(new ContractImport(name, inputs, outputs));
+		return this;
+	}
+
+	/**
+	 * import a contract
+	 *
+	 * @param contract contract to import
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addImport(ContractImport contract) {
+		this.items.add(contract);
+		return this;
+	}
+
+	/**
+	 * import contracts
+	 *
+	 * @param contracts a collection of contracts to import
+	 * @return this contract body builder
+	 */
+	public ContractBodyBuilder addImports(Collection<ContractImport> contracts) {
+		this.items.addAll(contracts);
+		return this;
+	}
+
+	/**
+	 * construct a contract body
+	 *
+	 * @return constructed contract body
+	 */
+	public ContractBody build() {
+		return new ContractBody(Location.NULL, items);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/builders/Kind2FunctionBuilder.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/builders/Kind2FunctionBuilder.java
@@ -1,0 +1,336 @@
+package jkind.lustre.builders;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import jkind.lustre.ContractBody;
+import jkind.lustre.Equation;
+import jkind.lustre.Expr;
+import jkind.lustre.IdExpr;
+import jkind.lustre.Kind2Function;
+import jkind.lustre.Location;
+import jkind.lustre.Type;
+import jkind.lustre.VarDecl;
+
+/**
+ * This class provides helper functions for constructing a kind2 function.
+ */
+public class Kind2FunctionBuilder {
+	private String id;
+	private List<VarDecl> inputs = new ArrayList<>();
+	private List<VarDecl> outputs = new ArrayList<>();
+	private ContractBody contractBody = null;
+	private List<VarDecl> locals = new ArrayList<>();
+	private List<Equation> equations = new ArrayList<>();
+	private List<String> properties = new ArrayList<>();
+	private List<Expr> assertions = new ArrayList<>();
+
+	/**
+	 * Constructor
+	 *
+	 * @param id name of the function
+	 */
+	public Kind2FunctionBuilder(String id) {
+		this.id = id;
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @param kind2Function function to clone
+	 */
+	public Kind2FunctionBuilder(Kind2Function Kind2Function) {
+		this.id = Kind2Function.id;
+		this.inputs = new ArrayList<>(Kind2Function.inputs);
+		this.outputs = new ArrayList<>(Kind2Function.outputs);
+		this.contractBody = Kind2Function.contractBody;
+		this.locals = new ArrayList<>(Kind2Function.locals);
+		this.equations = new ArrayList<>(Kind2Function.equations);
+		this.properties = new ArrayList<>(Kind2Function.properties);
+		this.assertions = new ArrayList<>(Kind2Function.assertions);
+	}
+
+	/**
+	 * set the function's name
+	 *
+	 * @param id name of the function
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder setId(String id) {
+		this.id = id;
+		return this;
+	}
+
+	/**
+	 * add an input to the function
+	 *
+	 * @param input the input to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addInput(VarDecl input) {
+		this.inputs.add(input);
+		return this;
+	}
+
+	/**
+	 * add inputs to the function
+	 *
+	 * @param inputs a collection of inputs to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addInputs(Collection<VarDecl> inputs) {
+		this.inputs.addAll(inputs);
+		return this;
+	}
+
+	/**
+	 * create an input to the function
+	 *
+	 * @param name name of input to the function
+	 * @param type name of input to the function
+	 * @return an expression referring to created input
+	 */
+	public IdExpr createInput(String name, Type type) {
+		this.inputs.add(new VarDecl(name, type));
+		return new IdExpr(name);
+	}
+
+	/**
+	 * remove all inputs to the function
+	 *
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder clearInputs() {
+		this.inputs.clear();
+		return this;
+	}
+
+	/**
+	 * add an output for the function
+	 *
+	 * @param output the output to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addOutput(VarDecl output) {
+		this.outputs.add(output);
+		return this;
+	}
+
+	/**
+	 * add outputs for the function
+	 *
+	 * @param outputs a collection of outputs to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addOutputs(Collection<VarDecl> outputs) {
+		this.outputs.addAll(outputs);
+		return this;
+	}
+
+	/**
+	 * create an output for the function
+	 *
+	 * @param name name of output to the function
+	 * @param type name of output to the function
+	 * @return an expression referring to created output
+	 */
+	public IdExpr createOutput(String name, Type type) {
+		this.outputs.add(new VarDecl(name, type));
+		return new IdExpr(name);
+	}
+
+	/**
+	 * remove all outputs for the function
+	 *
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder clearOutputs() {
+		this.outputs.clear();
+		return this;
+	}
+
+	/**
+	 * associate an inline contract with the function
+	 *
+	 * @param contractBody body of the inline contract
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder setContractBody(ContractBody contractBody) {
+		this.contractBody = contractBody;
+		return this;
+	}
+
+	/**
+	 * add a local var
+	 *
+	 * @param local the local var to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addLocal(VarDecl local) {
+		this.locals.add(local);
+		return this;
+	}
+
+	/**
+	 * add local vars
+	 *
+	 * @param locals a collection of local vars to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addLocals(Collection<VarDecl> locals) {
+		this.locals.addAll(locals);
+		return this;
+	}
+
+	/**
+	 * create a local var
+	 *
+	 * @param name name of local var
+	 * @param type name of local var
+	 * @return an expression referring to created local var
+	 */
+	public IdExpr createLocal(String name, Type type) {
+		this.locals.add(new VarDecl(name, type));
+		return new IdExpr(name);
+	}
+
+	/**
+	 * remove all local vars
+	 *
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder clearLocals() {
+		this.locals.clear();
+		return this;
+	}
+
+	/**
+	 * add an equation
+	 *
+	 * @param equation the equation to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addEquation(Equation equation) {
+		this.equations.add(equation);
+		return this;
+	}
+
+	/**
+	 * add an equation
+	 *
+	 * @param var  the left-hand side to define by the equation
+	 * @param expr the right-hand side of the equation
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addEquation(IdExpr var, Expr expr) {
+		this.equations.add(new Equation(var, expr));
+		return this;
+	}
+
+	/**
+	 * add equations
+	 *
+	 * @param equations a collection of equations to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addEquations(Collection<Equation> equations) {
+		this.equations.addAll(equations);
+		return this;
+	}
+
+	/**
+	 * remove all equations
+	 *
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder clearEquations() {
+		this.equations.clear();
+		return this;
+	}
+
+	/**
+	 * add an assertion
+	 *
+	 * @param assertion a boolean expression representing a constraint
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addAssertion(Expr assertion) {
+		this.assertions.add(assertion);
+		return this;
+	}
+
+	/**
+	 * add assertions
+	 *
+	 * @param assertions a collection of assertions to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addAssertions(Collection<Expr> assertions) {
+		this.assertions.addAll(assertions);
+		return this;
+	}
+
+	/**
+	 * remove all assertions
+	 *
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder clearAssertions() {
+		this.assertions.clear();
+		return this;
+	}
+
+	/**
+	 * add a property
+	 *
+	 * @param property constraint expressing the behavior of a node
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addProperty(String property) {
+		this.properties.add(property);
+		return this;
+	}
+
+	/**
+	 * add a property
+	 *
+	 * @param property a boolean var/constant
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addProperty(IdExpr property) {
+		this.properties.add(property.id);
+		return this;
+	}
+
+	/**
+	 * add properties
+	 *
+	 * @param property a collection of properties to add
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder addProperties(Collection<String> properties) {
+		this.properties.addAll(properties);
+		return this;
+	}
+
+	/**
+	 * remove all properties
+	 *
+	 * @return this function builder
+	 */
+	public Kind2FunctionBuilder clearProperties() {
+		this.properties.clear();
+		return this;
+	}
+
+	/**
+	 * construct a kind2 function
+	 *
+	 * @return constructed function
+	 */
+	public Kind2Function build() {
+		return new Kind2Function(Location.NULL, id, inputs, outputs, contractBody, locals, equations, assertions,
+				properties);
+	}
+}

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/builders/NodeBuilder.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/builders/NodeBuilder.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import jkind.lustre.Contract;
+import jkind.lustre.ContractBody;
 import jkind.lustre.Equation;
 import jkind.lustre.Expr;
 import jkind.lustre.IdExpr;
@@ -24,7 +24,7 @@ public class NodeBuilder {
 	private List<Expr> assertions = new ArrayList<>();
 	private List<String> ivc = new ArrayList<>();
 	private List<String> realizabilityInputs = null;
-	private Contract contract = null;
+	private ContractBody contractBody = null;
 
 	public NodeBuilder(String id) {
 		this.id = id;
@@ -40,7 +40,7 @@ public class NodeBuilder {
 		this.assertions = new ArrayList<>(node.assertions);
 		this.ivc = new ArrayList<>(node.ivc);
 		this.realizabilityInputs = Util.copyNullable(node.realizabilityInputs);
-		this.contract = node.contract;
+		this.contractBody = node.contractBody;
 	}
 
 	public NodeBuilder setId(String id) {
@@ -183,13 +183,13 @@ public class NodeBuilder {
 		return this;
 	}
 
-	public NodeBuilder setContract(Contract contract) {
-		this.contract = contract;
+	public NodeBuilder setContractBody(ContractBody contractBody) {
+		this.contractBody = contractBody;
 		return this;
 	}
 
 	public Node build() {
 		return new Node(Location.NULL, id, inputs, outputs, locals, equations, properties, assertions,
-				realizabilityInputs, contract, ivc);
+				realizabilityInputs, contractBody, ivc);
 	}
 }

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/builders/ProgramBuilder.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/builders/ProgramBuilder.java
@@ -5,7 +5,11 @@ import java.util.Collection;
 import java.util.List;
 
 import jkind.lustre.Constant;
+import jkind.lustre.Contract;
 import jkind.lustre.Function;
+import jkind.lustre.ImportedFunction;
+import jkind.lustre.ImportedNode;
+import jkind.lustre.Kind2Function;
 import jkind.lustre.Location;
 import jkind.lustre.Node;
 import jkind.lustre.Program;
@@ -14,8 +18,12 @@ import jkind.lustre.TypeDef;
 public class ProgramBuilder {
 	private List<TypeDef> types = new ArrayList<>();
 	private List<Constant> constants = new ArrayList<>();
-	private List<Node> nodes = new ArrayList<>();
 	private List<Function> functions = new ArrayList<>();
+	private List<ImportedFunction> importedFunctions = new ArrayList<>();
+	private List<ImportedNode> importedNodes = new ArrayList<>();
+	private List<Contract> contracts = new ArrayList<>();
+	private List<Kind2Function> kind2Functions = new ArrayList<>();
+	private List<Node> nodes = new ArrayList<>();
 	private String main;
 
 	public ProgramBuilder() {
@@ -24,8 +32,12 @@ public class ProgramBuilder {
 	public ProgramBuilder(Program program) {
 		this.types = new ArrayList<>(program.types);
 		this.constants = new ArrayList<>(program.constants);
-		this.nodes = new ArrayList<>(program.nodes);
 		this.functions = new ArrayList<>(program.functions);
+		this.importedFunctions = new ArrayList<>(program.importedFunctions);
+		this.importedNodes = new ArrayList<>(program.importedNodes);
+		this.contracts = new ArrayList<>(program.contracts);
+		this.kind2Functions = new ArrayList<>(program.kind2Functions);
+		this.nodes = new ArrayList<>(program.nodes);
 		this.main = program.main;
 	}
 
@@ -56,6 +68,66 @@ public class ProgramBuilder {
 
 	public ProgramBuilder clearConstants() {
 		this.constants.clear();
+		return this;
+	}
+
+	public ProgramBuilder addImportedFunction(ImportedFunction importedFunction) {
+		this.importedFunctions.add(importedFunction);
+		return this;
+	}
+
+	public ProgramBuilder addImportedFunctions(Collection<ImportedFunction> importedFunctions) {
+		this.importedFunctions.addAll(importedFunctions);
+		return this;
+	}
+
+	public ProgramBuilder clearImportedFunctions() {
+		this.importedFunctions.clear();
+		return this;
+	}
+
+	public ProgramBuilder addImportedNode(ImportedNode importedNode) {
+		this.importedNodes.add(importedNode);
+		return this;
+	}
+
+	public ProgramBuilder addImportedNodes(Collection<ImportedNode> importedNodes) {
+		this.importedNodes.addAll(importedNodes);
+		return this;
+	}
+
+	public ProgramBuilder clearImportedNodes() {
+		this.importedNodes.clear();
+		return this;
+	}
+
+	public ProgramBuilder addContract(Contract contract) {
+		this.contracts.add(contract);
+		return this;
+	}
+
+	public ProgramBuilder addContracts(Collection<Contract> contracts) {
+		this.contracts.addAll(contracts);
+		return this;
+	}
+
+	public ProgramBuilder clearContracts() {
+		this.contracts.clear();
+		return this;
+	}
+
+	public ProgramBuilder addKind2Function(Kind2Function kind2Function) {
+		this.kind2Functions.add(kind2Function);
+		return this;
+	}
+
+	public ProgramBuilder addKind2Functions(Collection<Kind2Function> kind2Functions) {
+		this.kind2Functions.addAll(kind2Functions);
+		return this;
+	}
+
+	public ProgramBuilder clearKind2Function() {
+		this.kind2Functions.clear();
 		return this;
 	}
 
@@ -95,6 +167,7 @@ public class ProgramBuilder {
 	}
 
 	public Program build() {
-		return new Program(Location.NULL, types, constants, functions, nodes, main);
+		return new Program(Location.NULL, types, constants, functions, importedFunctions, importedNodes, contracts,
+				kind2Functions, nodes, main);
 	}
 }

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/parsing/LustreToAstVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/parsing/LustreToAstVisitor.java
@@ -25,7 +25,7 @@ import jkind.lustre.BoolExpr;
 import jkind.lustre.CastExpr;
 import jkind.lustre.CondactExpr;
 import jkind.lustre.Constant;
-import jkind.lustre.Contract;
+import jkind.lustre.ContractBody;
 import jkind.lustre.EnumType;
 import jkind.lustre.Equation;
 import jkind.lustre.Expr;
@@ -109,7 +109,7 @@ public class LustreToAstVisitor extends LustreBaseVisitor<Object> {
 		List<Constant> constants = constants(ctx.constant());
 		List<Function> functions = functions(ctx.function());
 		List<Node> nodes = nodes(ctx.node());
-		return new Program(loc(ctx), types, constants, functions, nodes, main);
+		return new Program(loc(ctx), types, constants, functions, null, null, null, null, nodes, main);
 	}
 
 	private List<TypeDef> types(List<TypedefContext> ctxs) {
@@ -159,7 +159,7 @@ public class LustreToAstVisitor extends LustreBaseVisitor<Object> {
 		List<Expr> assertions = assertions(ctx.assertion());
 		List<String> ivc = ivc(ctx.ivc());
 		List<String> realizabilityInputs = realizabilityInputs(ctx.realizabilityInputs());
-		Contract contract = null;
+		ContractBody contractBody = null;
 		if (!ctx.main().isEmpty()) {
 			if (main == null) {
 				main = id;
@@ -168,7 +168,7 @@ public class LustreToAstVisitor extends LustreBaseVisitor<Object> {
 			}
 		}
 		return new Node(loc(ctx), id, inputs, outputs, locals, equations, properties, assertions, realizabilityInputs,
-				contract, ivc);
+				contractBody, ivc);
 	}
 
 	private List<VarDecl> varDecls(VarDeclListContext listCtx) {

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstIterVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstIterVisitor.java
@@ -25,8 +25,8 @@ import jkind.util.Util;
 
 public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, Void> {
 	@Override
-	public Void visit(Assume assumption) {
-		assumption.expr.accept(this);
+	public Void visit(Assume e) {
+		e.expr.accept(this);
 		return null;
 	}
 
@@ -37,16 +37,16 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	}
 
 	@Override
-	public Void visit(Contract contract) {
-		visitVarDecls(contract.inputs);
-		visitVarDecls(contract.outputs);
-		visit(contract.contractBody);
+	public Void visit(Contract e) {
+		visitVarDecls(e.inputs);
+		visitVarDecls(e.outputs);
+		visit(e.contractBody);
 		return null;
 	}
 
 	@Override
-	public Void visit(ContractBody contractBody) {
-		visitContractItems(contractBody.items);
+	public Void visit(ContractBody e) {
+		visitContractItems(e.items);
 		return null;
 	}
 
@@ -57,9 +57,9 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	}
 
 	@Override
-	public Void visit(ContractImport contractImport) {
-		visitExprs(contractImport.inputs);
-		visitExprs(Util.safeList(contractImport.outputs));
+	public Void visit(ContractImport e) {
+		visitExprs(e.inputs);
+		visitExprs(Util.safeList(e.outputs));
 		return null;
 	}
 
@@ -77,8 +77,8 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	}
 
 	@Override
-	public Void visit(Guarantee guarantee) {
-		guarantee.expr.accept(this);
+	public Void visit(Guarantee e) {
+		e.expr.accept(this);
 		return null;
 	}
 
@@ -86,8 +86,8 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	public Void visit(ImportedFunction e) {
 		visitVarDecls(e.inputs);
 		visitVarDecls(e.outputs);
-		// if (contract.contractBody != null) {
-		//	visit(contract.contractBody);
+		// if (e.contractBody != null) {
+		//	visit(e.contractBody);
 		// }
 		return null;
 	}
@@ -96,8 +96,8 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	public Void visit(ImportedNode e) {
 		visitVarDecls(e.inputs);
 		visitVarDecls(e.outputs);
-		// if (contract.contractBody != null) {
-		//	visit(contract.contractBody);
+		// if (e.contractBody != null) {
+		//	visit(e.contractBody);
 		// }
 		return null;
 	}
@@ -113,9 +113,9 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	}
 
 	@Override
-	public Void visit(Mode mode) {
-		visitExprs(mode.require);
-		visitExprs(mode.ensure);
+	public Void visit(Mode e) {
+		visitExprs(e.require);
+		visitExprs(e.ensure);
 		return null;
 	}
 
@@ -126,8 +126,8 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 		visitVarDecls(e.locals);
 		visitEquations(e.equations);
 		visitAssertions(e.assertions);
-		// if (contract.contractBody != null) {
-		//	visit(contract.contractBody);
+		// if (e.contractBody != null) {
+		//	visit(e.contractBody);
 		// }
 		return null;
 	}
@@ -220,8 +220,8 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	}
 
 	@Override
-	public Void visit(VarDef varDef) {
-		varDef.expr.accept(this);
+	public Void visit(VarDef e) {
+		e.expr.accept(this);
 		return null;
 	}
 }

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstIterVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstIterVisitor.java
@@ -2,20 +2,64 @@ package jkind.lustre.visitors;
 
 import java.util.List;
 
+import jkind.lustre.Assume;
 import jkind.lustre.Constant;
 import jkind.lustre.Contract;
+import jkind.lustre.ContractBody;
+import jkind.lustre.ContractImport;
+import jkind.lustre.ContractItem;
 import jkind.lustre.Equation;
 import jkind.lustre.Expr;
 import jkind.lustre.Function;
+import jkind.lustre.Guarantee;
+import jkind.lustre.ImportedFunction;
+import jkind.lustre.ImportedNode;
+import jkind.lustre.Kind2Function;
+import jkind.lustre.Mode;
 import jkind.lustre.Node;
 import jkind.lustre.Program;
 import jkind.lustre.TypeDef;
 import jkind.lustre.VarDecl;
+import jkind.lustre.VarDef;
+import jkind.util.Util;
 
 public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, Void> {
 	@Override
+	public Void visit(Assume assumption) {
+		assumption.expr.accept(this);
+		return null;
+	}
+
+	@Override
 	public Void visit(Constant e) {
 		e.expr.accept(this);
+		return null;
+	}
+
+	@Override
+	public Void visit(Contract contract) {
+		visitVarDecls(contract.inputs);
+		visitVarDecls(contract.outputs);
+		visit(contract.contractBody);
+		return null;
+	}
+
+	@Override
+	public Void visit(ContractBody contractBody) {
+		visitContractItems(contractBody.items);
+		return null;
+	}
+
+	protected void visitContractItems(List<ContractItem> es) {
+		for (ContractItem e : es) {
+			e.accept(this);
+		}
+	}
+
+	@Override
+	public Void visit(ContractImport contractImport) {
+		visitExprs(contractImport.inputs);
+		visitExprs(Util.safeList(contractImport.outputs));
 		return null;
 	}
 
@@ -33,12 +77,58 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	}
 
 	@Override
+	public Void visit(Guarantee guarantee) {
+		guarantee.expr.accept(this);
+		return null;
+	}
+
+	@Override
+	public Void visit(ImportedFunction e) {
+		visitVarDecls(e.inputs);
+		visitVarDecls(e.outputs);
+		// if (contract.contractBody != null) {
+		//	visit(contract.contractBody);
+		// }
+		return null;
+	}
+
+	@Override
+	public Void visit(ImportedNode e) {
+		visitVarDecls(e.inputs);
+		visitVarDecls(e.outputs);
+		// if (contract.contractBody != null) {
+		//	visit(contract.contractBody);
+		// }
+		return null;
+	}
+
+	@Override
+	public Void visit(Kind2Function e) {
+		visitVarDecls(e.inputs);
+		visitVarDecls(e.outputs);
+		visitVarDecls(e.locals);
+		visitEquations(e.equations);
+		visitAssertions(e.assertions);
+		return null;
+	}
+
+	@Override
+	public Void visit(Mode mode) {
+		visitExprs(mode.require);
+		visitExprs(mode.ensure);
+		return null;
+	}
+
+	@Override
 	public Void visit(Node e) {
 		visitVarDecls(e.inputs);
 		visitVarDecls(e.outputs);
 		visitVarDecls(e.locals);
 		visitEquations(e.equations);
 		visitAssertions(e.assertions);
+		// if (contract.contractBody != null) {
+		//	visit(contract.contractBody);
+		// }
 		return null;
 	}
 
@@ -63,6 +153,10 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 		visitTypeDefs(e.types);
 		visitConstants(e.constants);
 		visitFunctions(e.functions);
+		// visitImportedFunctions(e.importedFunctions);
+		// visitImportedNodes(e.importedNodes);
+		// visitContracts(e.contracts);
+		// visitKind2Functions(e.kind2Functions);
 		visitNodes(e.nodes);
 		return null;
 	}
@@ -85,6 +179,30 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 		}
 	}
 
+	protected void visitImportedFunctions(List<ImportedFunction> es) {
+		for (ImportedFunction e : es) {
+			visit(e);
+		}
+	}
+
+	protected void visitImportedNodes(List<ImportedNode> es) {
+		for (ImportedNode e : es) {
+			visit(e);
+		}
+	}
+
+	protected void visitContracts(List<Contract> es) {
+		for (Contract e : es) {
+			visit(e);
+		}
+	}
+
+	protected void visitKind2Functions(List<Kind2Function> es) {
+		for (Kind2Function e : es) {
+			visit(e);
+		}
+	}
+
 	protected void visitNodes(List<Node> es) {
 		for (Node e : es) {
 			visit(e);
@@ -102,9 +220,8 @@ public class AstIterVisitor extends ExprIterVisitor implements AstVisitor<Void, 
 	}
 
 	@Override
-	public Void visit(Contract contract) {
-		visitExprs(contract.requires);
-		visitExprs(contract.ensures);
+	public Void visit(VarDef varDef) {
+		varDef.expr.accept(this);
 		return null;
 	}
 }

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstMapVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstMapVisitor.java
@@ -27,8 +27,8 @@ import jkind.lustre.VarDef;
 
 public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Expr> {
 	@Override
-	public Assume visit(Assume assumption) {
-		return new Assume(assumption.location, assumption.expr.accept(this));
+	public Assume visit(Assume e) {
+		return new Assume(e.location, e.expr.accept(this));
 	}
 
 	@Override
@@ -37,17 +37,17 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 	}
 
 	@Override
-	public Contract visit(Contract contract) {
-		List<VarDecl> inputs = visitVarDecls(contract.inputs);
-		List<VarDecl> outputs = visitVarDecls(contract.outputs);
-		ContractBody contractBody = visit(contract.contractBody);
+	public Contract visit(Contract e) {
+		List<VarDecl> inputs = visitVarDecls(e.inputs);
+		List<VarDecl> outputs = visitVarDecls(e.outputs);
+		ContractBody contractBody = visit(e.contractBody);
 
-		return new Contract(contract.id, inputs, outputs, contractBody);
+		return new Contract(e.id, inputs, outputs, contractBody);
 	}
 
 	@Override
-	public ContractBody visit(ContractBody contractBody) {
-		return new ContractBody(visitContractItems(contractBody.items));
+	public ContractBody visit(ContractBody e) {
+		return new ContractBody(visitContractItems(e.items));
 	}
 
 	protected List<ContractItem> visitContractItems(List<? extends ContractItem> is) {
@@ -72,9 +72,9 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 	}
 
 	@Override
-	public ContractImport visit(ContractImport contractImport) {
-		return new ContractImport(contractImport.location, contractImport.id, visitExprs(contractImport.inputs),
-				visitExprs(contractImport.outputs).stream().map(e -> (IdExpr) e).collect(Collectors.toList()));
+	public ContractImport visit(ContractImport e) {
+		return new ContractImport(e.location, e.id, visitExprs(e.inputs),
+				visitExprs(e.outputs).stream().map(x -> (IdExpr) x).collect(Collectors.toList()));
 	}
 
 	@Override
@@ -91,8 +91,8 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 	}
 
 	@Override
-	public Guarantee visit(Guarantee guarantee) {
-		return new Guarantee(guarantee.location, guarantee.expr.accept(this));
+	public Guarantee visit(Guarantee e) {
+		return new Guarantee(e.location, e.expr.accept(this));
 	}
 
 	public ImportedFunction visit(ImportedFunction e) {
@@ -132,8 +132,8 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 	}
 
 	@Override
-	public Mode visit(Mode mode) {
-		return new Mode(mode.id, visitExprs(mode.require), visitExprs(mode.ensure));
+	public Mode visit(Mode e) {
+		return new Mode(e.id, visitExprs(e.require), visitExprs(e.ensure));
 	}
 
 	@Override
@@ -142,7 +142,7 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 		List<VarDecl> outputs = visitVarDecls(e.outputs);
 		// ContractBody contractBody = null;
 		// if (e.contractBody != null) {
-		// contractBody = visit(e.contractBody);
+		//	contractBody = visit(e.contractBody);
 		// }
 		List<VarDecl> locals = visitVarDecls(e.locals);
 		List<Equation> equations = visitEquations(e.equations);
@@ -198,8 +198,7 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 		List<TypeDef> types = visitTypeDefs(e.types);
 		List<Constant> constants = visitConstants(e.constants);
 		List<Function> functions = visitFunctions(e.functions);
-		// List<ImportedFunction> importedFunctions =
-		// visitImportedFunctions(e.importedFunctions);
+		// List<ImportedFunction> importedFunctions = visitImportedFunctions(e.importedFunctions);
 		// List<ImportedNode> importedNodes = visitImportedNodes(e.importedNodes);
 		// List<Contract> contracts = visitContracts(e.contracts);
 		// List<Kind2Function> kind2Functions = visitKind2Functions(e.kind2Functions);
@@ -252,7 +251,7 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 	}
 
 	@Override
-	public VarDef visit(VarDef varDef) {
-		return new VarDef(varDef.location, visit(varDef.varDecl), varDef.expr.accept(this));
+	public VarDef visit(VarDef e) {
+		return new VarDef(e.location, visit(e.varDecl), e.expr.accept(this));
 	}
 }

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstMapVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstMapVisitor.java
@@ -1,22 +1,80 @@
 package jkind.lustre.visitors;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import jkind.lustre.Assume;
 import jkind.lustre.Ast;
 import jkind.lustre.Constant;
 import jkind.lustre.Contract;
+import jkind.lustre.ContractBody;
+import jkind.lustre.ContractImport;
+import jkind.lustre.ContractItem;
 import jkind.lustre.Equation;
 import jkind.lustre.Expr;
 import jkind.lustre.Function;
+import jkind.lustre.Guarantee;
+import jkind.lustre.IdExpr;
+import jkind.lustre.ImportedFunction;
+import jkind.lustre.ImportedNode;
+import jkind.lustre.Kind2Function;
+import jkind.lustre.Mode;
 import jkind.lustre.Node;
 import jkind.lustre.Program;
 import jkind.lustre.TypeDef;
 import jkind.lustre.VarDecl;
+import jkind.lustre.VarDef;
 
 public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Expr> {
 	@Override
+	public Assume visit(Assume assumption) {
+		return new Assume(assumption.location, assumption.expr.accept(this));
+	}
+
+	@Override
 	public Constant visit(Constant e) {
 		return new Constant(e.location, e.id, e.type, e.expr.accept(this));
+	}
+
+	@Override
+	public Contract visit(Contract contract) {
+		List<VarDecl> inputs = visitVarDecls(contract.inputs);
+		List<VarDecl> outputs = visitVarDecls(contract.outputs);
+		ContractBody contractBody = visit(contract.contractBody);
+
+		return new Contract(contract.id, inputs, outputs, contractBody);
+	}
+
+	@Override
+	public ContractBody visit(ContractBody contractBody) {
+		return new ContractBody(visitContractItems(contractBody.items));
+	}
+
+	protected List<ContractItem> visitContractItems(List<? extends ContractItem> is) {
+		is.get(0).accept(this);
+		return map(this::visitContractItem, is);
+	}
+
+	protected ContractItem visitContractItem(ContractItem i) {
+		if (i instanceof Assume) {
+			return visit((Assume) i);
+		} else if (i instanceof Constant) {
+			return visit((Constant) i);
+		} else if (i instanceof ContractImport) {
+			return visit((ContractImport) i);
+		} else if (i instanceof Guarantee) {
+			return visit((Guarantee) i);
+		} else if (i instanceof Mode) {
+			return visit((Mode) i);
+		} else {
+			return visit((VarDef) i);
+		}
+	}
+
+	@Override
+	public ContractImport visit(ContractImport contractImport) {
+		return new ContractImport(contractImport.location, contractImport.id, visitExprs(contractImport.inputs),
+				visitExprs(contractImport.outputs).stream().map(e -> (IdExpr) e).collect(Collectors.toList()));
 	}
 
 	@Override
@@ -33,18 +91,67 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 	}
 
 	@Override
+	public Guarantee visit(Guarantee guarantee) {
+		return new Guarantee(guarantee.location, guarantee.expr.accept(this));
+	}
+
+	public ImportedFunction visit(ImportedFunction e) {
+		List<VarDecl> inputs = visitVarDecls(e.inputs);
+		List<VarDecl> outputs = visitVarDecls(e.outputs);
+		ContractBody contractBody = null;
+		if (e.contractBody != null) {
+			contractBody = visit(e.contractBody);
+		}
+		return new ImportedFunction(e.location, e.id, inputs, outputs, contractBody);
+	}
+
+	public ImportedNode visit(ImportedNode e) {
+		List<VarDecl> inputs = visitVarDecls(e.inputs);
+		List<VarDecl> outputs = visitVarDecls(e.outputs);
+		ContractBody contractBody = null;
+		if (e.contractBody != null) {
+			contractBody = visit(e.contractBody);
+		}
+		return new ImportedNode(e.location, e.id, inputs, outputs, contractBody);
+	}
+
+	@Override
+	public Kind2Function visit(Kind2Function e) {
+		List<VarDecl> inputs = visitVarDecls(e.inputs);
+		List<VarDecl> outputs = visitVarDecls(e.outputs);
+		ContractBody contractBody = null;
+		if (e.contractBody != null) {
+			contractBody = visit(e.contractBody);
+		}
+		List<VarDecl> locals = visitVarDecls(e.locals);
+		List<Equation> equations = visitEquations(e.equations);
+		List<Expr> assertions = visitAssertions(e.assertions);
+		List<String> properties = visitProperties(e.properties);
+		return new Kind2Function(e.location, e.id, inputs, outputs, contractBody, locals, equations, assertions,
+				properties);
+	}
+
+	@Override
+	public Mode visit(Mode mode) {
+		return new Mode(mode.id, visitExprs(mode.require), visitExprs(mode.ensure));
+	}
+
+	@Override
 	public Node visit(Node e) {
 		List<VarDecl> inputs = visitVarDecls(e.inputs);
 		List<VarDecl> outputs = visitVarDecls(e.outputs);
+		// ContractBody contractBody = null;
+		// if (e.contractBody != null) {
+		// contractBody = visit(e.contractBody);
+		// }
 		List<VarDecl> locals = visitVarDecls(e.locals);
 		List<Equation> equations = visitEquations(e.equations);
 		List<Expr> assertions = visitAssertions(e.assertions);
 		List<String> properties = visitProperties(e.properties);
 		List<String> ivc = visitIvc(e.ivc);
 		List<String> realizabilityInputs = visitRealizabilityInputs(e.realizabilityInputs);
-		Contract contract = visit(e.contract);
 		return new Node(e.location, e.id, inputs, outputs, locals, equations, properties, assertions,
-				realizabilityInputs, contract, ivc);
+				realizabilityInputs, e.contractBody, ivc);
 	}
 
 	protected List<VarDecl> visitVarDecls(List<VarDecl> es) {
@@ -91,8 +198,15 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 		List<TypeDef> types = visitTypeDefs(e.types);
 		List<Constant> constants = visitConstants(e.constants);
 		List<Function> functions = visitFunctions(e.functions);
+		// List<ImportedFunction> importedFunctions =
+		// visitImportedFunctions(e.importedFunctions);
+		// List<ImportedNode> importedNodes = visitImportedNodes(e.importedNodes);
+		// List<Contract> contracts = visitContracts(e.contracts);
+		// List<Kind2Function> kind2Functions = visitKind2Functions(e.kind2Functions);
+
 		List<Node> nodes = visitNodes(e.nodes);
-		return new Program(e.location, types, constants, functions, nodes, e.main);
+		return new Program(e.location, types, constants, functions, e.importedFunctions, e.importedNodes, e.contracts,
+				e.kind2Functions, nodes, e.main);
 	}
 
 	protected List<TypeDef> visitTypeDefs(List<TypeDef> es) {
@@ -100,6 +214,22 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 	}
 
 	protected List<Constant> visitConstants(List<Constant> es) {
+		return map(this::visit, es);
+	}
+
+	protected List<ImportedFunction> visitImportedFunctions(List<ImportedFunction> es) {
+		return map(this::visit, es);
+	}
+
+	protected List<ImportedNode> visitImportedNodes(List<ImportedNode> es) {
+		return map(this::visit, es);
+	}
+
+	protected List<Contract> visitContracts(List<Contract> es) {
+		return map(this::visit, es);
+	}
+
+	protected List<Kind2Function> visitKind2Functions(List<Kind2Function> es) {
 		return map(this::visit, es);
 	}
 
@@ -122,10 +252,7 @@ public class AstMapVisitor extends ExprMapVisitor implements AstVisitor<Ast, Exp
 	}
 
 	@Override
-	public Contract visit(Contract contract) {
-		if (contract == null) {
-			return null;
-		}
-		return new Contract(visitExprs(contract.requires), visitExprs(contract.ensures));
+	public VarDef visit(VarDef varDef) {
+		return new VarDef(varDef.location, visit(varDef.varDecl), varDef.expr.accept(this));
 	}
 }

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/AstVisitor.java
@@ -1,20 +1,47 @@
 package jkind.lustre.visitors;
 
+import jkind.lustre.Assume;
 import jkind.lustre.Constant;
 import jkind.lustre.Contract;
+import jkind.lustre.ContractBody;
+import jkind.lustre.ContractImport;
 import jkind.lustre.Equation;
 import jkind.lustre.Function;
+import jkind.lustre.Guarantee;
+import jkind.lustre.ImportedFunction;
+import jkind.lustre.ImportedNode;
+import jkind.lustre.Kind2Function;
+import jkind.lustre.Mode;
 import jkind.lustre.Node;
 import jkind.lustre.Program;
 import jkind.lustre.TypeDef;
 import jkind.lustre.VarDecl;
+import jkind.lustre.VarDef;
 
 public interface AstVisitor<T, S extends T> extends ExprVisitor<S> {
+	public T visit(Assume assumption);
+
 	public T visit(Constant constant);
+
+	public T visit(Contract contract);
+
+	public T visit(ContractBody contractBody);
+
+	public T visit(ContractImport contractImport);
 
 	public T visit(Equation equation);
 
 	public T visit(Function function);
+
+	public T visit(Guarantee guarantee);
+
+	public T visit(ImportedFunction importedFunction);
+
+	public T visit(ImportedNode importedNode);
+
+	public T visit(Kind2Function kind2Function);
+
+	public T visit(Mode mode);
 
 	public T visit(Node node);
 
@@ -24,5 +51,5 @@ public interface AstVisitor<T, S extends T> extends ExprVisitor<S> {
 
 	public T visit(VarDecl varDecl);
 
-	public T visit(Contract contract);
+	public T visit(VarDef varDef);
 }

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/Evaluator.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/Evaluator.java
@@ -17,6 +17,7 @@ import jkind.lustre.Expr;
 import jkind.lustre.FunctionCallExpr;
 import jkind.lustre.IfThenElseExpr;
 import jkind.lustre.IntExpr;
+import jkind.lustre.ModeRefExpr;
 import jkind.lustre.NodeCallExpr;
 import jkind.lustre.RealExpr;
 import jkind.lustre.RecordAccessExpr;
@@ -124,6 +125,11 @@ public abstract class Evaluator implements ExprVisitor<Value> {
 	@Override
 	public Value visit(IntExpr e) {
 		return new IntegerValue(e.value);
+	}
+
+	@Override
+	public Value visit(ModeRefExpr e) {
+		return null;
 	}
 
 	@Override

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprConjunctiveVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprConjunctiveVisitor.java
@@ -14,6 +14,7 @@ import jkind.lustre.FunctionCallExpr;
 import jkind.lustre.IdExpr;
 import jkind.lustre.IfThenElseExpr;
 import jkind.lustre.IntExpr;
+import jkind.lustre.ModeRefExpr;
 import jkind.lustre.NodeCallExpr;
 import jkind.lustre.RealExpr;
 import jkind.lustre.RecordAccessExpr;
@@ -75,6 +76,11 @@ public class ExprConjunctiveVisitor implements ExprVisitor<Boolean> {
 
 	@Override
 	public Boolean visit(IntExpr e) {
+		return true;
+	}
+
+	@Override
+	public Boolean visit(ModeRefExpr e) {
 		return true;
 	}
 

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprDisjunctiveVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprDisjunctiveVisitor.java
@@ -14,6 +14,7 @@ import jkind.lustre.FunctionCallExpr;
 import jkind.lustre.IdExpr;
 import jkind.lustre.IfThenElseExpr;
 import jkind.lustre.IntExpr;
+import jkind.lustre.ModeRefExpr;
 import jkind.lustre.NodeCallExpr;
 import jkind.lustre.RealExpr;
 import jkind.lustre.RecordAccessExpr;
@@ -75,6 +76,11 @@ public class ExprDisjunctiveVisitor implements ExprVisitor<Boolean> {
 
 	@Override
 	public Boolean visit(IntExpr e) {
+		return false;
+	}
+
+	@Override
+	public Boolean visit(ModeRefExpr e) {
 		return false;
 	}
 

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprIterVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprIterVisitor.java
@@ -14,6 +14,7 @@ import jkind.lustre.FunctionCallExpr;
 import jkind.lustre.IdExpr;
 import jkind.lustre.IfThenElseExpr;
 import jkind.lustre.IntExpr;
+import jkind.lustre.ModeRefExpr;
 import jkind.lustre.NodeCallExpr;
 import jkind.lustre.RealExpr;
 import jkind.lustre.RecordAccessExpr;
@@ -91,6 +92,11 @@ public class ExprIterVisitor implements ExprVisitor<Void> {
 
 	@Override
 	public Void visit(IntExpr e) {
+		return null;
+	}
+
+	@Override
+	public Void visit(ModeRefExpr e) {
 		return null;
 	}
 

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprMapVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprMapVisitor.java
@@ -20,6 +20,7 @@ import jkind.lustre.FunctionCallExpr;
 import jkind.lustre.IdExpr;
 import jkind.lustre.IfThenElseExpr;
 import jkind.lustre.IntExpr;
+import jkind.lustre.ModeRefExpr;
 import jkind.lustre.NodeCallExpr;
 import jkind.lustre.RealExpr;
 import jkind.lustre.RecordAccessExpr;
@@ -93,6 +94,11 @@ public class ExprMapVisitor implements ExprVisitor<Expr> {
 
 	@Override
 	public Expr visit(IntExpr e) {
+		return e;
+	}
+
+	@Override
+	public Expr visit(ModeRefExpr e) {
 		return e;
 	}
 

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprVisitor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/ExprVisitor.java
@@ -11,6 +11,7 @@ import jkind.lustre.FunctionCallExpr;
 import jkind.lustre.IdExpr;
 import jkind.lustre.IfThenElseExpr;
 import jkind.lustre.IntExpr;
+import jkind.lustre.ModeRefExpr;
 import jkind.lustre.NodeCallExpr;
 import jkind.lustre.RealExpr;
 import jkind.lustre.RecordAccessExpr;
@@ -41,6 +42,8 @@ public interface ExprVisitor<T> {
 	public T visit(IfThenElseExpr e);
 
 	public T visit(IntExpr e);
+
+	public T visit(ModeRefExpr e);
 
 	public T visit(NodeCallExpr e);
 

--- a/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/TypeReconstructor.java
+++ b/com.collins.trustedsystems.jkindapi/src/jkind/lustre/visitors/TypeReconstructor.java
@@ -21,6 +21,7 @@ import jkind.lustre.FunctionCallExpr;
 import jkind.lustre.IdExpr;
 import jkind.lustre.IfThenElseExpr;
 import jkind.lustre.IntExpr;
+import jkind.lustre.ModeRefExpr;
 import jkind.lustre.NamedType;
 import jkind.lustre.Node;
 import jkind.lustre.NodeCallExpr;
@@ -191,6 +192,11 @@ public class TypeReconstructor implements ExprVisitor<Type> {
 	@Override
 	public Type visit(IntExpr e) {
 		return NamedType.INT;
+	}
+
+	@Override
+	public Type visit(ModeRefExpr e) {
+		return NamedType.BOOL;
 	}
 
 	@Override


### PR DESCRIPTION
This PR extends JKind's Lustre AST to support Kind 2's contract items (assumptions, guarantees, modes, etc.) and other related constructs. There are two things to note in this PR:
- Order of contract items inside a contract matter. Modes cannot be referenced before their definition, for example. This behavior is captured by the `ContractItem` class, which the above items inherit from.
- Functions in Kind 2 are _stateless_ nodes and have bodies. Those functions are represented by `Kind2Function` class to avoid confusion with JKind's `Function`, which represents uninterpreted functions.